### PR TITLE
Exposing Modernizr as a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,18 @@
 
 var modernizr = require("modernizr");
 
+function wrapOutput(output) {
+  // Exposing Modernizr as a module.
+  return ';(function(window){\n' +
+            output + '\n' +
+            'module.exports = window.Modernizr;\n' +
+          '})(window);';
+}
+
 module.exports = function (config) {
     var cb = this.async();
 
     modernizr.build(JSON.parse(config), function (output) {
-        cb(null, output);
+        cb(null, wrapOutput(output));
     });
 };


### PR DESCRIPTION
This changes allows the following code.

```
import Modernizr from 'modernizr';

if (!Modernizr.promises) {
    ...
}
```
