### PR TITLE
Config is already a JS object, no need to parse.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function wrapOutput(output) {
 module.exports = function (config) {
     var cb = this.async();
 
-    modernizr.build(JSON.parse(config), function (output) {
+    modernizr.build(config, function (output) {
         cb(null, wrapOutput(output));
     });
 };


### PR DESCRIPTION
Hi there,

The config file is already parsed when received as argument, so there is no need to call `JSON.parse()` here. This adds support to comments etc. to `.modernizrrc` :+1:

Cheers!
