### PR TITLE
Don't pollute globals & allow using .modernizrrc.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ module.exports = {
   module: {
     loaders: [
       {
-        test: /\.modernizrrc$/,
+        test: /\.modernizrrc.js$/,
         loader: "modernizr"
+      },
+      {
+        test: /\.modernizrrc(\.json)?$/,
+        loader: "modernizr!json"
       }
     ]
   },

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function wrapOutput(output) {
     return ";(function(window){\n" +
             output + "\n" +
             "module.exports = window.Modernizr;\n" +
-            "})(window);";
+            "})({});";
 }
 
 module.exports = function (config) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
 
     var cb = this.async();
 
-    modernizr.build(JSON.parse(config), function (output) {
+    modernizr.build(this.exec(config, this.resource), function (output) {
         cb(null, wrapOutput(output));
     });
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "^3.3.1",
     "eslint-config-peerigon": "^6.0.0",
     "eslint-plugin-jsdoc": "^2.3.1",
+    "json-loader": "^0.5.4",
     "modernizr": "^3.3.1",
     "temp": "^0.8.3",
     "webpack": "^1.13.2"

--- a/test/fixtures/.modernizrrc.js
+++ b/test/fixtures/.modernizrrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "minify": false,
   "options": [
     "setClasses"

--- a/test/fixtures/.modernizrrc.json
+++ b/test/fixtures/.modernizrrc.json
@@ -1,0 +1,11 @@
+{
+  "minify": false,
+  "options": [
+    "setClasses"
+  ],
+  "feature-detects": [
+    "test/css/flexbox",
+    "test/es6/promises",
+    "test/serviceworker"
+  ]
+}

--- a/test/fixtures/index-json.js
+++ b/test/fixtures/index-json.js
@@ -1,0 +1,1 @@
+require("./.modernizrrc.json");

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,3 +1,3 @@
 "use strict";
 
-require("./.modernizrrc");
+require("./.modernizrrc.js");

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ const webpackConfig = {
     module: {
         loaders: [
             {
-                test: /\.modernizrrc$/,
+                test: /\.modernizrrc\.js$/,
                 loader: path.resolve(__dirname, "../index.js")
             }
         ]
@@ -40,4 +40,3 @@ test.cb((t) => {
         t.end();
     });
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -6,26 +6,60 @@ import path from "path";
 
 temp.track();
 
-const tempDir = temp.mkdirSync();
-const webpackConfig = {
-    context: "./fixtures",
-    entry: "./index.js",
-    output: {
-        path: `${tempDir}`,
-        filename: "bundle.js"
-    },
-    module: {
-        loaders: [
-            {
-                test: /\.modernizrrc\.js$/,
-                loader: path.resolve(__dirname, "../index.js")
-            }
-        ]
-    }
-};
+test.cb("js", (t) => {
+    const tempDir = temp.mkdirSync();
 
-test.cb((t) => {
-    webpack(webpackConfig, (err, stats) => {
+    webpack({
+        entry: "./fixtures/index.js",
+        output: {
+            path: `${tempDir}`,
+            filename: "bundle.js"
+        },
+        module: {
+            loaders: [
+                {
+                    test: /\.modernizrrc\.js$/,
+                    loader: path.resolve(__dirname, "../index.js")
+                }
+            ]
+        }
+    }, (err, stats) => {
+        if (err) {
+            t.end(err);
+            return;
+        }
+
+        const build = fs.readFileSync(`${tempDir}/bundle.js`, "utf8");
+
+        t.true(/addTest\('flexbox/.test(build));
+        t.true(/addTest\('promise/.test(build));
+        t.true(/addTest\('serviceworker/.test(build));
+
+        t.end();
+    });
+});
+
+test.cb("json", (t) => {
+    const tempDir = temp.mkdirSync();
+
+    webpack({
+        entry: "./fixtures/index-json.js",
+        output: {
+            path: `${tempDir}`,
+            filename: "bundle.js"
+        },
+        module: {
+            loaders: [
+                {
+                    test: /\.modernizrrc\.json$/,
+                    loaders: [
+                        path.resolve(__dirname, "../index.js"),
+                        "json-loader"
+                    ]
+                }
+            ]
+        }
+    }, (err, stats) => {
         if (err) {
             t.end(err);
             return;


### PR DESCRIPTION
Hi!

This PR makes sure that window isn't polluted with Modernizr. This makes using it more consistent with other CommonJS packages. You can always write `window.Modernizr = require('./.modernizrrc');`.

It also allows using JS as configuration. This means that the [loader does a single task](https://webpack.github.io/docs/how-to-write-a-loader.html#do-only-a-single-task) and users can create dynamic configurations. For example:

```js
// .modernizrrc.js
import featureDetects from "./feature-detects";
export default {
   minify: false,
   // Get feature detects elsewhere
   "feature-detects": featureDetects
};
```

Or even:

```js
// .modernizrrc.js
import config from "./modernizrrc.json";
export default config;
```

Another way is to use a JSON is to use the JSON loader:

```js
// webpack.config.js
module.exports = {
  module: {
    loaders: [
      {
        test: /\.modernizrrc.js$/,
        loader: "modernizr"
      },
      {
        test: /\.modernizrrc(\.json)?$/,
        loader: "modernizr!json"
      }
    ]
  },
  resolve: {
    alias: {
      modernizr$: path.resolve(__dirname, "path/to/.modernizrrc")
    }
  }
}
```
