### PR TITLE
Fix issue caused by not polluting global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,18 @@ var modernizr = require("modernizr");
 function wrapOutput(output) {
     // Exposing Modernizr as a module.
     return ";(function(window){\n" +
-            output + "\n" +
-            "module.exports = window.Modernizr;\n" +
-            "})({});";
+           "var hadGlobal = 'Modernizr' in window;\n" +
+           "var oldGlobal = window.Modernizr;\n" +
+           output + "\n" +
+           "module.exports = window.Modernizr;\n" +
+           "if (hadGlobal) { window.Modernizr = oldGlobal; }\n" +
+           "else { delete window.Modernizr; }\n" +
+           "})(window);";
 }
 
 module.exports = function (config) {
     if (typeof this.cacheable === 'function') {
-        this.cacheable()
+        this.cacheable();
     }
 
     var cb = this.async();


### PR DESCRIPTION
Fixes #24, which happened after #23. This issue was caused because Modernizr needs to use the `window` object in its tests. Thus, tests such as `'addEventListener' in window` would return false no matter what because we set `window` to `{}`.

This PR fixes the issue. I'm not sure it's the best way (it would be nice if Modernizr allowed us to configure the exports object), but it should deal with any edge cases, even if the user has their own `window.Modernizr`, without simply reverting to polluting the global scope.