### PR TITLE
Add `json-loader` as dependency in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 ## Installation
 
 ```
-$ npm install --save-dev modernizr modernizr-loader
+$ npm install --save-dev modernizr modernizr-loader json-loader
 ```
+
+You need to install `json-loader` in order to make the `mordernizr-loader` configuration work with webpack.
 
 ## Initialization
 


### PR DESCRIPTION
You need to install `json-loader` in order to integrate `modernizr-loader` with Webpack.

I got the error

> Module not found: Error: Cannot resolve module 'json' in …

I could solve this issue by adding `json-loader` as a dependency.

From my pov this should be stated in the docs.